### PR TITLE
Correct __slots__ chapter

### DIFF
--- a/__slots__magic.rst
+++ b/__slots__magic.rst
@@ -5,11 +5,11 @@ In Python every class can have instance attributes. By default Python
 uses a dict to store an object’s instance attributes. This is really
 helpful as it allows setting arbitrary new attributes at runtime.
 
-However, in small classes with known attributes it might be a
+However, for small classes with known attributes it might be a
 bottleneck. The ``dict`` wastes a lot of RAM. Python can’t just allocate
 a static amount of memory at object creation to store all the
 attributes. Therefore it sucks a lot of RAM if you create a lot of
-classes (I am talking in thousands and millions). Still there is a way
+objects (I am talking in thousands and millions). Still there is a way
 to circumvent this issue. It involves the useage of ``__slots__`` to
 tell Python not to use a dict, and only allocate space for a fixed set
 of attributes. Here is an example with and without ``__slots__``:
@@ -19,9 +19,9 @@ of attributes. Here is an example with and without ``__slots__``:
 .. code:: python
 
     class MyClass(object):
-        def __init__(name, class):
+        def __init__(name, identifier):
             self.name = name
-            self.class = class
+            self.identifier = identifier
             self.set_up()
         # ...
 
@@ -30,10 +30,10 @@ of attributes. Here is an example with and without ``__slots__``:
 .. code:: python
 
     class MyClass(object):
-        __slots__ = ['name', 'class']
-        def __init__(name, class):
+        __slots__ = ['name', 'identifier']
+        def __init__(name, identifier):
             self.name = name
-            self.class = class
+            self.identifier = identifier
             self.set_up()
         # ...
 


### PR DESCRIPTION
The text confuses classes and objects. But more importantly, the code doesn't actually compile, since `class` is a keyword.