### PR TITLE
Update collections for defaultDict typo

### DIFF
--- a/collections.rst
+++ b/collections.rst
@@ -34,7 +34,7 @@ not. So we can do:
      
     favourite_colours = defaultdict(list)
      
-    for name, colour in order:
+    for name, colour in colours:
         favourite_colours[name].append(colour)
      
     print(favourite_colours)


### PR DESCRIPTION
Typo, 'order' doesn't exist