### PR TITLE
Create deque instance directly from range object.

### DIFF
--- a/collections.rst
+++ b/collections.rst
@@ -158,7 +158,7 @@ You can pop values from both sides of the deque:
 
 .. code:: python
 
-    d = deque([i for i in range(5)])
+    d = deque(range(5))
     print(len(d))
     # Output: 5
 


### PR DESCRIPTION
Explicitly iterating over the range object in the form of a list comprehension (BTW, a generator expression here would be more appropriate, and easier to read) without transforming or filtering elements is unnecessary, so the range object can be used to directly feed its values to the deque on instantiation.