### PR TITLE
Fix issue in the decorator class example

### DIFF
--- a/decorators.rst
+++ b/decorators.rst
@@ -440,9 +440,9 @@ will not be covered here).
         A logit implementation for sending emails to admins
         when the function is called.
         '''
-        def __init__(self, email='admin@myproject.com', *args, **kwargs):
+        def __init__(self, func, email='admin@myproject.com'):
             self.email = email
-            super(email_logit, self).__init__(*args, **kwargs)
+            super(email_logit, self).__init__(func)
             
         def notify(self):
             # Send an email to self.email


### PR DESCRIPTION
`super(email_logit, self).__init__(*args, **kwargs)` doesn't seem to work here. I think the correct way is `super(email_logit, self).__init__(func)` taking in the `func` argument in the `__init__` of the sub class. 